### PR TITLE
Make file report visible by default

### DIFF
--- a/reporter.css
+++ b/reporter.css
@@ -327,5 +327,5 @@ code .number { color: #2F6FAD }
 .count { font-weight: bold; border-radius: 3px }
 .pass .count { background: #BFFFBF;}
 .error .count { background: #F8D5D8; color: red}
-.file-report { display: none; }
+.file-report { display: visible; }
 #coverage { font-size: 12px; }


### PR DESCRIPTION
Unless I'm missing something, `.file-report` needs to be visible. If it's hidden then I cannot see the report. Maybe there's some toggle switch I'm missing somewhere? I am using RequireJS to load everything, so maybe that's the problem for me?
